### PR TITLE
introduce the arrow size to compute its position

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,10 +76,12 @@ class Card extends React.Component {
     let arrowStyle = assign(this.defaultArrowStyle, this.props.style.arrowStyle)
     let bgBorderColor = arrowStyle.borderColor ? arrowStyle.borderColor : 'transparent'
 
+    let fgSize = 8
+    let bgSize = 9
     let fgColorBorder = `10px solid ${arrowStyle.color}`
-    let fgTransBorder = '8px solid transparent'
+    let fgTransBorder = `${fgSize}px solid transparent`
     let bgColorBorder = `11px solid ${bgBorderColor}`
-    let bgTransBorder = '9px solid transparent'
+    let bgTransBorder = `${bgSize}px solid transparent`
 
     let {position, arrow} = this.props
 
@@ -143,16 +145,16 @@ class Card extends React.Component {
 
       if (arrow === 'right') {
         fgStyle.left = null
-        fgStyle.right = this.margin + 1
+        fgStyle.right = this.margin + 1 - fgSize
         fgStyle.marginLeft = 0
         bgStyle.left = null
-        bgStyle.right = this.margin
+        bgStyle.right = this.margin - fgSize
         bgStyle.marginLeft = 0
       }
       if (arrow === 'left') {
-        fgStyle.left = this.margin + 1
+        fgStyle.left = this.margin + 1 - fgSize
         fgStyle.marginLeft = 0
-        bgStyle.left = this.margin
+        bgStyle.left = this.margin - fgSize
         bgStyle.marginLeft = 0
       }
     }


### PR DESCRIPTION
The arrow's size was not take in consideration to compute its position in the following context:
- position: top/bottom
- arrow: left/right

It's almost invisible on a medium element size but on a small element like an icon we can detect the problem:
![image](https://user-images.githubusercontent.com/4126690/29709152-a2713946-898b-11e7-920f-a2e89bd1b367.png)

With the fix even on small element the arrow is visually center:

![image](https://user-images.githubusercontent.com/4126690/29709268-fe889652-898b-11e7-9581-d3ccf5784411.png)

